### PR TITLE
perf: 検出器を1プロセス1回ロードに（多ページOCRを約33%高速化）

### DIFF
--- a/src/ocr.py
+++ b/src/ocr.py
@@ -19,7 +19,12 @@ from ndl_parser import convert_to_xml_string3
 from reading_order.xy_cut.eval import eval_xml
 from tools.ndlkoten2tei import convert_tei
 
+_DETECTOR_CACHE = {}
 def get_detector(args):
+    _det_key = (args.det_weights, args.det_classes, args.det_score_threshold,
+                args.det_conf_threshold, args.det_iou_threshold, args.device)
+    if _det_key in _DETECTOR_CACHE:
+        return _DETECTOR_CACHE[_det_key]
     weights_path = args.det_weights
     classes_path = args.det_classes
     assert os.path.isfile(weights_path), f"There's no weight file with name {weights_path}"
@@ -30,6 +35,7 @@ def get_detector(args):
                       conf_thresold=args.det_conf_threshold,
                       iou_threshold=args.det_iou_threshold,
                       device=args.device)
+    _DETECTOR_CACHE[_det_key] = detector
     return detector
 def get_recognizer(args):
     weights_path = args.rec_weights


### PR DESCRIPTION
## 概要 / Summary
`get_detector()` が `inference_on_detector()` 内で**ページ毎に**呼ばれ、RTMDet の ONNX `InferenceSession` を毎ページ再構築しています。プロセス内で1回だけロードして使い回すようにします。

`get_detector()` caches the detector instead of rebuilding the RTMDet ONNX `InferenceSession` on every page.

## 効果 / Performance
CPU (Apple Silicon), 18枚 / 1プロセス: **27.9s → 約18s**（1.55 → 約1.0 s/枚）、**約33%短縮**。多ページ文書ほど効果が大きくなります。
~33% less CPU time on multi-page input.

## 正当性 / Correctness
出力は**バイト単位で一致**します。高解像(6592×4672)/低解像/白紙/90度回転/縦横混在の多様な画像で `diff -rq`（および JSON の SHA256）が一致し、検出器の構築回数が N回→1回になることも計器で確認しました。
Byte-identical output, verified with `diff -rq` / JSON SHA256 across a diverse image set.

## 設計メモ / Notes
- キャッシュは検出器に影響する引数 `(det_weights, det_classes, det_score_threshold, det_conf_threshold, det_iou_threshold, device)` をキーにしているため、1プロセス内で閾値やモデルを変えて呼んでも正しい検出器を返します。
  The cache is **keyed on the detector-affecting args**, so a threshold sweep / model comparison in one process stays correct.
- `RTMDet.detect()` は `self.image_width/height` を共有するため逐次呼び出し前提です（現行の呼び出し元はいずれも単一スレッドで `detect` を呼び、`ThreadPoolExecutor` は `recognizer.read` のみ並列化）。
  `RTMDet.detect()` is not re-entrant; the cached detector is intended for sequential `detect()` calls, matching all current callers.
- GUI は元々起動時に検出器を1回ロードして再利用しているため、本変更は GUI では実質 no-op です。
  The GUI already loads the detector once, so this is a no-op there.
